### PR TITLE
Fix link to changelog

### DIFF
--- a/web/src/index.html
+++ b/web/src/index.html
@@ -153,7 +153,7 @@
                         <div translate="{{ 'DISCLAIMER_FEEDBACK' }}"></div>
                         <br />
                         Starbow ErosJS <%=version%><br />
-                        <a href="https://github.com/Starbow/erosd/blob/websockets/web/CHANGELOG.md">{{ 'CHANGELOG' | translate }}</a>
+                        <a href="https://github.com/Starbow/erosd/blob/master/web/CHANGELOG.md">{{ 'CHANGELOG' | translate }}</a>
 
                     </div>
                 </div>


### PR DESCRIPTION
Not sure if you accept PRs, however the link to CHANGELOG.md on http://eros.starbowmod.com/ is currently not working (it links to a `websockets`-branch that does not exist anymore I think).
This changes the link to master.